### PR TITLE
Add typescript declarations and resolve npm audit issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "text-entity",
-  "version": "1.0.0",
+  "name": "stringtree-js",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1093,9 +1093,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "stringtree builds a prefix trees from keys/values",
   "main": "index.js",
+  "types": "stringtree-js.d.ts",
   "scripts": {
     "test": "node node_modules/nyc/bin/nyc.js --reporter=lcov --exclude=spec node_modules/jasmine/bin/jasmine.js && nyc report --reporter=text-lcov | coveralls",
     "gendocs": "node node_modules/jsdoc/jsdoc.js lib lib/jsdoc README.md -c .jsdoc.js -d docs"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "types": "stringtree-js.d.ts",
   "scripts": {
-    "test": "node node_modules/nyc/bin/nyc.js --reporter=lcov --exclude=spec node_modules/jasmine/bin/jasmine.js && nyc report --reporter=text-lcov | coveralls",
-    "gendocs": "node node_modules/jsdoc/jsdoc.js lib lib/jsdoc README.md -c .jsdoc.js -d docs"
+    "test-only": "jasmine",
+    "test": "nyc --reporter=lcov --exclude=spec npm run test-only && nyc report --reporter=text-lcov | coveralls",
+    "gendocs": "jsdoc lib lib/jsdoc README.md -c .jsdoc.js -d docs"
   },
   "author": "Tom Cully <mail@tomcully.com>",
   "license": "0BSD",

--- a/stringtree-js.d.ts
+++ b/stringtree-js.d.ts
@@ -1,0 +1,99 @@
+export class StringTree<V = unknown> {
+  constructor(options?: { ignoreCase: boolean = false } = {});
+
+  /**
+   * Set the value of the specified key.
+   */
+  set(key: string, value: V): void;
+
+  /**
+   * Get the value of the specified key if the value has been set,
+   * otherwise null.
+   */
+  get(key: string): V | null;
+
+  /**
+   * Search for the specified string. The search results will
+   * contain the node for this string in `n`, if there is one (else
+   * `null`), and the last found node with a value in `l`.
+   */
+  getNode(key: string): StringTree.NodeSearchResult<V>;
+
+  /**
+   * Remove the value with the specified key, if there is one.
+   */
+  clear(key: string): void;
+
+  /**
+   * Find the value with the longest prefix of the given key, or null
+   * if there are no values set for any prefixes of the given key.
+   */
+  partial(key: string): V;
+
+  /**
+   * Find all values whose keys have the specified key as a prefix
+   * (including any value defined for the key).
+   */
+  prefix(key: string): Record<string, V>;
+
+  /**
+   * Find the value whose key has the longest prefix of the given string,
+   * where the key starts at `offset` index into `str` and stops before
+   * index `limit`.
+   * @param str A string containing the key to look for.
+   * @param offset The starting offset into `str` of the key to look for
+   * @param limit The limiting offset into `str` of the key to look for.
+   *
+   * @returns An object with the value that has the longest prefix
+   * of the specified substring, and the offset into the given string
+   * where the key of the value ends.
+   */
+  parse(
+    str: string,
+    offset: number = 0,
+    limit: number = str.length
+  ): { offset: number; value: V | null };
+}
+
+declare namespace StringTree {
+  export type Character = string & { length: 0 | 1 };
+
+  export interface Node<V> {
+    c: Character;
+
+    /**
+     * Child nodes.
+     */
+    k: Record<Character, Node>;
+
+    /**
+     * The value at this node, or `null` if no value is defined for
+     * the key.
+     */
+    v: V | null;
+
+    /**
+     * The parent node.
+     */
+    p: Node;
+  }
+
+  /**
+   * Represents the results of searching the tree for a specific key.
+   */
+  export interface NodeSearchResult<V> {
+    /**
+     * The node with the requested key, or null if the node doesn't
+     * exist. The node will exist if there is a value defined for the
+     * requested key, or if the requested key is a prefix of any
+     * defined keys.
+     */
+    n: Node<V> | null;
+
+    /**
+     * The node with the longest prefix of the requested key that actually
+     * has a value defined.
+     */
+    l: Node<V> | null;
+  }
+}


### PR DESCRIPTION
Added a typescript declaration files. Also resolved npm audit issues and added a "test-only" npm script that works doesn't rely on coveralls, so will work on forks that don't have a repo set up on coveralls =).

Note: removed the explicit invocation of dev-dependency scripts in the npm scripts; npm automatically populates your system path with these directories so you can invoke them directly.